### PR TITLE
fix: 修复在M1/M2芯片的mac打开的浏览器实例很卡很慢的问题

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ const initLogger = require('./lib/logger');
 const Constants = require('./lib/constants');
 const execSync = require('child_process').execSync;
 
+const isArm64 = () => {
+  return execSync('uname -m').toString().trim() === 'arm64';
+}
+
 const checkHttpsCA = (options) => {
   // create cert when you want to use https features
   // please manually trust this rootCA when it is the first time you run it
@@ -672,6 +676,7 @@ module.exports = (options, logger, callbackFn) => {
           serverPath = options.openUrl
             || ((`${protocol}://${options.hosts[0]}` || serverHost) + options.openPath);
           let cmd = [
+            isArm64() ? 'arch -arm64' : '',
             options.browserApp.replace(/\x20/g, '\\ '),
             `-proxy-server="http://127.0.0.1:${options.proxyPort}"`,
             '--auto-open-devtools-for-tabs',


### PR DESCRIPTION
M1/M2 芯片用的是 arm64 架构，默认 Chrome 浏览器的版本是 arm64 架构（帮助 -> 关于 Chrome 可以查看），但是 sonic 启动的独立的浏览器实例是 x86 架构的，在 M1/M2 芯片的 mac 里运行很卡很慢，相关 issue：

* https://github.com/microsoft/playwright/issues/23914
* https://github.com/microsoft/playwright/issues/17193

解决方案，在 M1/M2 芯片 的 mac 里启动的时候指定为 arm64 版本的 Chrome